### PR TITLE
fix(codewalker/ytyp): portal attachment parsing

### DIFF
--- a/src/core/files/codewalker/ytyp.ts
+++ b/src/core/files/codewalker/ytyp.ts
@@ -82,12 +82,18 @@ export class CMloArchetypeDef {
       const to = parseInt(rawMloPortal.roomTo.$.value);
 
       const attachedObjects = rawMloPortal.attachedObjects
-        .split(' ')
+        .split(/\s/)
         .filter(entity => !!entity)
         .map(entityIdx => {
           const parsedEntityIdx = parseInt(entityIdx);
-
-          return this.entities[parsedEntityIdx];
+          if (parsedEntityIdx < this.entities.length)
+          {
+            return this.entities[parsedEntityIdx];
+          }
+          else
+          {
+            console.log('CMloArchetypeDef: getting portals ... invalid ref', entityIdx, parsedEntityIdx);
+          }
         });
 
       const flags = parseInt(rawMloPortal.flags.$.value);


### PR DESCRIPTION
When more than 10 entities are attached to a portal they are placed on multiple lines by CodeWalker export.
Splitting on any whitespace resolves null entries being created. 
Also verify that index is within the array and log if not.