### PR TITLE
fix(audioOcclusion): generate occlusionHash precisely

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@babel/preset-env": "^7.14.0",
     "@babel/preset-react": "^7.13.13",
     "@babel/preset-typescript": "^7.13.0",
+    "@types/big.js": "^6.1.2",
     "@types/node": "^15.0.1",
     "@types/react": "^17.0.4",
     "@types/react-dom": "^17.0.3",
@@ -59,6 +60,7 @@
     "webpack-dev-server": "^3.11.2"
   },
   "dependencies": {
+    "big.js": "^6.1.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-icons": "^4.2.0",

--- a/src/core/classes/audioOcclusion/index.ts
+++ b/src/core/classes/audioOcclusion/index.ts
@@ -5,6 +5,7 @@ import Interior from '../interior';
 import Node from './node';
 import PathNodeItem from './pathNodeitem';
 import Path from './path';
+import { Big } from 'big.js';
 
 export interface PortalEntity {
   linkType: number;
@@ -71,7 +72,10 @@ export default class AudioOcclusion {
       archetypeNameHash = joaat(this.interior.name, true);
     }
 
-    return archetypeNameHash ^ (pos.x * 100) ^ (pos.y * 100) ^ (pos.z * 100);
+    return archetypeNameHash ^ 
+      pos.x.times(100).round(0, Big.roundDown).toNumber() ^
+      pos.y.times(100).round(0, Big.roundDown).toNumber() ^
+      pos.z.times(100).round(0, Big.roundDown).toNumber();
   }
 
   private getPortalsEntities(): PortalEntity[][] {

--- a/src/core/files/codewalker/ymap.ts
+++ b/src/core/files/codewalker/ymap.ts
@@ -1,6 +1,7 @@
 import { isCMloInstanceDef } from '../../utils';
 
 import * as XML from '../../types/xml';
+import Big from 'big.js';
 
 export class CMapData {
   public entitiesExtentsMin: Vector3;
@@ -39,9 +40,9 @@ export class CMapData {
     const pos = rawData.CMapData.entitiesExtentsMin.$;
 
     return {
-      x: parseFloat(pos.x),
-      y: parseFloat(pos.y),
-      z: parseFloat(pos.z),
+      x: new Big(pos.x),
+      y: new Big(pos.y),
+      z: new Big(pos.z),
     };
   }
 
@@ -49,9 +50,9 @@ export class CMapData {
     const pos = rawData.CMapData.entitiesExtentsMax.$;
 
     return {
-      x: parseFloat(pos.x),
-      y: parseFloat(pos.y),
-      z: parseFloat(pos.z),
+      x: new Big(pos.x),
+      y: new Big(pos.y),
+      z: new Big(pos.z),
     };
   }
 
@@ -63,9 +64,9 @@ export class CMapData {
     const pos = mloInstance.position.$;
 
     return {
-      x: parseFloat(pos.x),
-      y: parseFloat(pos.y),
-      z: parseFloat(pos.z),
+      x: new Big(pos.x),
+      y: new Big(pos.y),
+      z: new Big(pos.z),
     };
   }
 }

--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -1,5 +1,7 @@
+import { Big } from "big.js";
+
 interface Vector3 {
-  x: number;
-  y: number;
-  z: number;
+  x: Big;
+  y: Big;
+  z: Big;
 }


### PR DESCRIPTION
Some coordinates cannot be represented correctly in JavaScript's number format and lead to the incorrect occlusionHash being generated.
Using arbitrary-precision decimal arithmetic (big.js) will correct the precision of the calculation for the occlusion hash.