### PR TITLE
feat: add tool settings

### DIFF
--- a/src/core/formats/codewalker/index.ts
+++ b/src/core/formats/codewalker/index.ts
@@ -242,6 +242,7 @@ export class CodeWalkerFormat {
   public async writeNaOcclusionInteriorMetadata(
     targetPath: string,
     interiorMetadata: naOcclusionInteriorMetadata,
+    isDebug?: boolean,
   ): Promise<string> {
     const { portalInfoList, pathNodeList, interiorProxyHash } = interiorMetadata;
 
@@ -297,11 +298,17 @@ export class CodeWalkerFormat {
             PathNodeKey: {
               $: {
                 value: convertToInt32(pathNodeChild.pathNode.key),
+                debug: isDebug
+                  ? `${pathNodeChild.pathNode.nodeFrom.index} -> ${pathNodeChild.pathNode.nodeTo.index}`
+                  : undefined,
               },
             },
             PortalInfoIdx: {
               $: {
                 value: pathNodeChild.portalInfo.infoIndex,
+                debug: isDebug
+                  ? `${pathNodeChild.portalInfo.roomIdx} -> ${pathNodeChild.portalInfo.destRoomIdx}`
+                  : undefined,
               },
             },
           };
@@ -312,6 +319,7 @@ export class CodeWalkerFormat {
         Key: {
           $: {
             value: convertToInt32(pathNode.key),
+            debug: isDebug ? `${pathNode.nodeFrom.index} -> ${pathNode.nodeTo.index}` : undefined,
           },
         },
         PathNodeChildList: pathNodeChildListObject,

--- a/src/electron/common/types/settings.ts
+++ b/src/electron/common/types/settings.ts
@@ -1,0 +1,9 @@
+export enum SettingsAPI {
+  GET = 'settings/get',
+  SET = 'settings/set',
+}
+
+export type SerializedSettings = {
+  bulkEditPortalEntities: boolean;
+  writeDebugInfoToXML: boolean;
+};

--- a/src/electron/main/app.ts
+++ b/src/electron/main/app.ts
@@ -2,6 +2,8 @@ import { BrowserWindow } from 'electron';
 
 import { CodeWalkerFormat } from '@/core/formats/codewalker';
 
+import { Settings } from './settings';
+
 import { ProjectManager } from './project-manager';
 import { InteriorManager } from './interior-manager';
 
@@ -12,6 +14,8 @@ export class Application {
   private mainWindow: BrowserWindow;
 
   public codeWalkerFormat: CodeWalkerFormat;
+
+  public settings: Settings;
 
   public projectManager: ProjectManager;
   public interiorManager: InteriorManager;
@@ -24,6 +28,8 @@ export class Application {
     }
 
     this.codeWalkerFormat = new CodeWalkerFormat();
+
+    this.settings = new Settings();
 
     this.projectManager = new ProjectManager(this);
     this.interiorManager = new InteriorManager(this);

--- a/src/electron/main/interior-manager.ts
+++ b/src/electron/main/interior-manager.ts
@@ -97,12 +97,22 @@ export class InteriorManager {
 
     const { naOcclusionInteriorMetadata } = interior;
 
-    const portalInfo = naOcclusionInteriorMetadata.portalInfoList[portalInfoIndex];
+    const { portalInfoList } = naOcclusionInteriorMetadata;
+
+    const portalInfo = portalInfoList[portalInfoIndex];
     if (!portalInfo) return;
 
     const portalEntity = portalInfo.portalEntityList[entityIndex];
 
-    Object.assign(portalEntity, data);
+    if (this.application.settings.bulkEditPortalEntities) {
+      const portalEntities = portalInfoList.flatMap(portalInfo => portalInfo.portalEntityList);
+
+      portalEntities.forEach(
+        entity => entity.entityModelHashKey === portalEntity.entityModelHashKey && Object.assign(entity, data),
+      );
+    } else {
+      Object.assign(portalEntity, data);
+    }
   }
 
   public updateInteriorRoomAudioGameData(

--- a/src/electron/main/project-manager.ts
+++ b/src/electron/main/project-manager.ts
@@ -162,6 +162,7 @@ export class ProjectManager {
         filePath = await this.application.codeWalkerFormat.writeNaOcclusionInteriorMetadata(
           path,
           naOcclusionInteriorMetadata,
+          this.application.settings.writeDebugInfoToXML,
         );
       } catch {
         return err('FAILED_TO_WRITE_NA_OCCLUSION_INTERIOR_METADATA_FILE');

--- a/src/electron/main/settings.ts
+++ b/src/electron/main/settings.ts
@@ -1,5 +1,7 @@
 import { ipcMain, Event } from 'electron';
 
+import { ok } from '@/electron/common';
+
 import { SerializedSettings, SettingsAPI } from '@/electron/common/types/settings';
 
 const hasStrangeProperty = <T>(object: T, properties: (keyof T)[]): boolean => {
@@ -30,12 +32,12 @@ export class Settings {
     Object.assign(this, data);
   }
 
-  public serialize(): SerializedSettings {
+  public serialize(): Result<string, SerializedSettings> {
     const { bulkEditPortalEntities, writeDebugInfoToXML } = this;
 
-    return {
+    return ok({
       bulkEditPortalEntities,
       writeDebugInfoToXML,
-    };
+    });
   }
 }

--- a/src/electron/main/settings.ts
+++ b/src/electron/main/settings.ts
@@ -1,0 +1,41 @@
+import { ipcMain, Event } from 'electron';
+
+import { SerializedSettings, SettingsAPI } from '@/electron/common/types/settings';
+
+const hasStrangeProperty = <T>(object: T, properties: (keyof T)[]): boolean => {
+  const keys = Object.keys(object);
+
+  return keys.some(key => !properties.includes(key as keyof T));
+};
+
+const ALLOWED_SETTINGS: Array<keyof SerializedSettings> = ['bulkEditPortalEntities', 'writeDebugInfoToXML'];
+
+export class Settings {
+  public bulkEditPortalEntities: boolean;
+  public writeDebugInfoToXML: boolean;
+
+  constructor() {
+    this.bulkEditPortalEntities = true;
+    this.writeDebugInfoToXML = false;
+
+    ipcMain.handle(SettingsAPI.GET, this.serialize.bind(this));
+    ipcMain.on(SettingsAPI.SET, (event: Event, data: Partial<SerializedSettings>) => this.update(data));
+  }
+
+  public update(data: Partial<SerializedSettings>): void {
+    if (hasStrangeProperty(data, ALLOWED_SETTINGS)) {
+      return console.warn(`Attempted to change a not allowed settings property ${data}`);
+    }
+
+    Object.assign(this, data);
+  }
+
+  public serialize(): SerializedSettings {
+    const { bulkEditPortalEntities, writeDebugInfoToXML } = this;
+
+    return {
+      bulkEditPortalEntities,
+      writeDebugInfoToXML,
+    };
+  }
+}

--- a/src/electron/main/settings.ts
+++ b/src/electron/main/settings.ts
@@ -17,7 +17,7 @@ export class Settings {
   public writeDebugInfoToXML: boolean;
 
   constructor() {
-    this.bulkEditPortalEntities = true;
+    this.bulkEditPortalEntities = false;
     this.writeDebugInfoToXML = false;
 
     ipcMain.handle(SettingsAPI.GET, this.serialize.bind(this));

--- a/src/electron/renderer/features/settings/components/Settings/index.tsx
+++ b/src/electron/renderer/features/settings/components/Settings/index.tsx
@@ -9,15 +9,31 @@ import { SettingsEntry, SettingsCheckbox } from './styles';
 const HEADER_TITLE = 'Settings';
 
 export const Settings = (): JSX.Element => {
-  const { settings } = useSettings();
+  const { settings, updateSettings } = useSettings();
+
+  if (!settings) {
+    return null;
+  }
+
+  const { bulkEditPortalEntities, writeDebugInfoToXML } = settings;
 
   return (
     <Container>
       <Header title={HEADER_TITLE} />
       <Content>
         <SettingsEntry>
-          <SettingsCheckbox checked={settings.bulkEditPortalEntities} />
+          <SettingsCheckbox
+            checked={bulkEditPortalEntities}
+            onClick={() => updateSettings({ bulkEditPortalEntities: !bulkEditPortalEntities })}
+          />
           <label>Bulk edit portal entities</label>
+        </SettingsEntry>
+        <SettingsEntry>
+          <SettingsCheckbox
+            checked={writeDebugInfoToXML}
+            onClick={() => updateSettings({ writeDebugInfoToXML: !writeDebugInfoToXML })}
+          />
+          <label>Write debug information to the generated XML</label>
         </SettingsEntry>
       </Content>
     </Container>


### PR DESCRIPTION
Add two useful settings:

- **bulkEditPortalEntities**: If enabled, will update all entities with the same hash when you edit a portal entity.
- **writeDebugInfoToXML**: If enabled, will write the path nodes and portal info directions to the .ymt XML.

  ```XML
  <Item>
    <Key value="1174415896" debug="2 -> 1"/>
    <PathNodeChildList itemType="naOcclusionPathNodeChildMetadata">
      <Item>
        <PathNodeKey value="0" debug="2 -> 2"/>
        <PortalInfoIdx value="9" debug="2 -> 1"/>
      </Item>
    </PathNodeChildList>
  </Item>
  ```