### PR TITLE
change(electron/renderer): changes displaying portal info and entities

### DIFF
--- a/src/electron/renderer/features/entities/components/PortalInfoEntityList/index.tsx
+++ b/src/electron/renderer/features/entities/components/PortalInfoEntityList/index.tsx
@@ -46,58 +46,64 @@ export const PortalInfoEntityList = (): JSX.Element => {
 
     let renderedPortals = 0;
 
-    portalInfoList.forEach(portalInfo => {
-      const { enabled, portalEntityList } = portalInfo;
+    portalInfoList
+      .sort((a, b) => a.portalIndex - b.portalIndex)
+      .forEach(portalInfo => {
+        const { portalEntityList } = portalInfo;
 
-      if (!enabled) return;
-      if (!portalEntityList.length) return;
+        if (!portalEntityList.length) return;
 
-      renderedPortals++;
+        renderedPortals++;
 
-      const isEven = (renderedPortals + 1) % 2 === 0;
-      const rowSpan = portalEntityList.length;
+        const isEven = (renderedPortals + 1) % 2 === 0;
+        const rowSpan = portalEntityList.length;
 
-      portalEntityList.forEach((portalEntity, portalEntityIndex) => {
-        const { maxOcclusion, entityModelName, entityModelHashKey, isDoor, isGlass } = portalEntity;
+        portalEntityList.forEach((portalEntity, portalEntityIndex) => {
+          const { maxOcclusion, entityModelName, entityModelHashKey, isDoor, isGlass } = portalEntity;
 
-        const key = `${portalInfo.infoIndex}:${portalEntityIndex}`;
+          const key = `${portalInfo.infoIndex}:${portalEntityIndex}`;
 
-        const isFirstEntity = portalEntityIndex === 0;
+          const isFirstEntity = portalEntityIndex === 0;
 
-        rows.push(
-          <tr key={key} className={isEven ? 'even' : 'odd'}>
-            {isFirstEntity && <td rowSpan={rowSpan}>{portalInfo.portalIndex}</td>}
-            <td>{entityModelName ?? entityModelHashKey}</td>
-            <td>
-              <SmallInput
-                value={maxOcclusion}
-                type="number"
-                min={MAX_OCCLUSION_MIN}
-                max={MAX_OCCLUSION_MAX}
-                step={MAX_OCCLUSION_STEP}
-                onChange={e => updateMaxOcclusion(portalInfo.infoIndex, portalEntityIndex, e.target.value)}
-              />
-            </td>
-            <td>
-              {
-                <Checkbox
-                  checked={isDoor}
-                  onClick={() => updateIsDoor(portalInfo.infoIndex, portalEntityIndex, !isDoor)}
+          rows.push(
+            <tr key={key} className={isEven ? 'even' : 'odd'}>
+              {isFirstEntity && (
+                <>
+                  <td rowSpan={rowSpan}>{portalInfo.portalIndex}</td>
+                  <td rowSpan={rowSpan}>{`${portalInfo.roomIdx} -> ${portalInfo.destRoomIdx}`}</td>
+                </>
+              )}
+              <td>{entityModelName ?? entityModelHashKey}</td>
+              <td>
+                <SmallInput
+                  value={maxOcclusion}
+                  type="number"
+                  min={MAX_OCCLUSION_MIN}
+                  max={MAX_OCCLUSION_MAX}
+                  step={MAX_OCCLUSION_STEP}
+                  onChange={e => updateMaxOcclusion(portalInfo.infoIndex, portalEntityIndex, e.target.value)}
                 />
-              }
-            </td>
-            <td>
-              {
-                <Checkbox
-                  checked={isGlass}
-                  onClick={() => updateIsGlass(portalInfo.infoIndex, portalEntityIndex, !isGlass)}
-                />
-              }
-            </td>
-          </tr>,
-        );
+              </td>
+              <td>
+                {
+                  <Checkbox
+                    checked={isDoor}
+                    onClick={() => updateIsDoor(portalInfo.infoIndex, portalEntityIndex, !isDoor)}
+                  />
+                }
+              </td>
+              <td>
+                {
+                  <Checkbox
+                    checked={isGlass}
+                    onClick={() => updateIsGlass(portalInfo.infoIndex, portalEntityIndex, !isGlass)}
+                  />
+                }
+              </td>
+            </tr>,
+          );
+        });
       });
-    });
 
     return rows;
   };
@@ -107,7 +113,8 @@ export const PortalInfoEntityList = (): JSX.Element => {
       <Table alternatedRowColors={false}>
         <thead>
           <tr>
-            <th>Portal</th>
+            <th>Portal index</th>
+            <th>Rooms</th>
             <th>Model</th>
             <th>Max occlusion</th>
             <th>Is door</th>

--- a/src/electron/renderer/features/portals/components/PortalInfoList/index.tsx
+++ b/src/electron/renderer/features/portals/components/PortalInfoList/index.tsx
@@ -13,44 +13,42 @@ export const PortalInfoList = (): JSX.Element => {
     return null;
   }
 
-  const portalInfoList = interior.naOcclusionInteriorMetadata.portalInfoList;
-
   const setPortalInfoEnabled = (portalInfoIndex: number, enabled: boolean): void => {
     updatePortalInfo(interior.identifier, portalInfoIndex, { enabled });
     fetchInterior();
   };
+
+  const portalInfoList = interior.naOcclusionInteriorMetadata.portalInfoList.sort(
+    (a, b) => a.portalIndex + a.destRoomIdx - (b.portalIndex + b.destRoomIdx),
+  );
 
   return (
     <TableContainer>
       <Table>
         <thead>
           <tr>
-            <th>Index</th>
-            <th>Room from</th>
-            <th>Room to</th>
+            <th>Portal index</th>
+            <th>Rooms</th>
             <th>Interior from</th>
             <th>Interior to</th>
             <th>Enabled</th>
           </tr>
         </thead>
         <tbody>
-          {portalInfoList
-            .sort((a, b) => a.portalIndex - b.portalIndex)
-            .map(portalInfo => (
-              <tr key={portalInfo.infoIndex}>
-                <td>{portalInfo.portalIndex}</td>
-                <td>{portalInfo.destRoomIdx}</td>
-                <td>{portalInfo.roomIdx}</td>
-                <td>{portalInfo.interiorProxyHash}</td>
-                <td>{portalInfo.destInteriorHash}</td>
-                <td>
-                  <Checkbox
-                    checked={portalInfo.enabled}
-                    onClick={() => setPortalInfoEnabled(portalInfo.infoIndex, !portalInfo.enabled)}
-                  />
-                </td>
-              </tr>
-            ))}
+          {portalInfoList.map(portalInfo => (
+            <tr key={portalInfo.infoIndex}>
+              <td>{portalInfo.portalIndex}</td>
+              <td>{`${portalInfo.destRoomIdx} -> ${portalInfo.roomIdx}`}</td>
+              <td>{portalInfo.interiorProxyHash}</td>
+              <td>{portalInfo.destInteriorHash}</td>
+              <td>
+                <Checkbox
+                  checked={portalInfo.enabled}
+                  onClick={() => setPortalInfoEnabled(portalInfo.infoIndex, !portalInfo.enabled)}
+                />
+              </td>
+            </tr>
+          ))}
         </tbody>
       </Table>
     </TableContainer>


### PR DESCRIPTION
Improves the ordering of portals and portal entities, and also improves how the portal direction is displayed.

![image](https://user-images.githubusercontent.com/48810400/202249027-e5d9303c-2936-4fce-982c-67070f974f55.png)
